### PR TITLE
Fix issues with sysctl not applying configs

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -12,7 +12,7 @@ flatten = (o) ->
 
 module.exports = ->
   @then @inject_flow => # allow all @define to be evaluated before entering here
-    return unless @server.sysctl?.params?
+    return unless typeof @server.sysctl?.params is "object"
     
     @then @log "setting sysctl parameters..."
     for key, value of flatten @server.sysctl.params

--- a/index.coffee
+++ b/index.coffee
@@ -11,15 +11,16 @@ flatten = (o) ->
   return res
 
 module.exports = ->
-  return unless @server.sysctl?.params
+  @then @inject_flow => # allow all @define to be evaluated before entering here
+    return unless @server.sysctl?.params
+    
+    @then @log "setting sysctl parameters..."
+    for key, value in flatten @server.sysctl.params
+      # remove any lines referring to the same key; this prevents duplicates
+      @then @execute "sed -i '/^#{key}/d' /etc/sysctl.conf", sudo: true
 
-  @then @log "setting sysctl parameters..."
-  for key, value in flatten @server.sysctl.params
-    # remove any lines referring to the same key; this prevents duplicates
-    @then @execute "sed -i '/^#{key}/d' /etc/sysctl.conf", sudo: true
+      # append ip and hostnames
+      @then @execute "echo #{key} = #{value} | sudo tee -a /etc/sysctl.conf >/dev/null"
 
-    # append ip and hostnames
-    @then @execute "echo #{key} = #{value} | sudo tee -a /etc/sysctl.conf >/dev/null"
-
-  # reload sysctl.conf
-  @then @execute "sysctl -q -p /etc/sysctl.conf", sudo: true
+    # reload sysctl.conf
+    @then @execute "sysctl -q -p /etc/sysctl.conf", sudo: true

--- a/index.coffee
+++ b/index.coffee
@@ -19,7 +19,7 @@ module.exports = ->
       # remove any lines referring to the same key; this prevents duplicates
       @then @execute "sed -i '/^#{key}/d' /etc/sysctl.conf", sudo: true
 
-      # append ip and hostnames
+      # append key and value
       @then @execute "echo #{key} = #{value} | sudo tee -a /etc/sysctl.conf >/dev/null"
 
     # reload sysctl.conf

--- a/index.coffee
+++ b/index.coffee
@@ -12,10 +12,10 @@ flatten = (o) ->
 
 module.exports = ->
   @then @inject_flow => # allow all @define to be evaluated before entering here
-    return unless @server.sysctl?.params
+    return unless @server.sysctl?.params?
     
     @then @log "setting sysctl parameters..."
-    for key, value in flatten @server.sysctl.params
+    for key, value of flatten @server.sysctl.params
       # remove any lines referring to the same key; this prevents duplicates
       @then @execute "sed -i '/^#{key}/d' /etc/sysctl.conf", sudo: true
 


### PR DESCRIPTION
- Check if params exists, not just sysctl parameter
- Iterator was using different syntax, preventing loop from running
- Changed text of one comment to better describe command to which it was referring
- Mike's change to get @define variables at beginning of execution
